### PR TITLE
Table method: default .select() returns a SELECT

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -118,14 +118,14 @@ const introspectCommand = Command.make(
               .join("");
 
             return [
-              `export class ${className} extends Table("${tableName}", {`,
+              `export const ${className} = Table("${tableName}", {`,
               ...Object.entries(columns as TableGenFile[string][string]).map(
                 ([column, definition]) =>
                   `  ${column}: ${asType(canonicalType(definition.type), {
                     nullable: definition.not_null ? false : undefined,
                   })},`,
               ),
-              `}) {}`,
+              `});`,
               ``,
             ];
           }),

--- a/src/query/from-item.ts
+++ b/src/query/from-item.ts
@@ -41,6 +41,7 @@ export type FromToSelectArgs<F extends RowLike, J extends Joins> = [
 ];
 
 const methods = [
+  "as",
   "toSelectArgs",
   "joinTables",
   "joinWithType",
@@ -106,6 +107,17 @@ export class FromItem<F extends RowLike = RowLike, J extends Joins = Joins>
         );
       }
     };
+  }
+
+  as<A extends string>(alias: A): FromItem<F, J> {
+    const queryAlias = new QueryAlias(alias);
+    return new FromItem(
+      this.rawFromExpr,
+      queryAlias,
+      this.joinAliases,
+      aliasRowLike(queryAlias, this.from),
+      this.joins,
+    );
   }
 
   asFromItem(): FromItem<F, J> {

--- a/src/query/table-select.test.ts
+++ b/src/query/table-select.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import * as db from "../gen/tables";
+import * as Types from "../types";
+import { dummyDb, withDb } from "../test/db";
+import { testDb } from "../db.test";
+import { assert, Equals } from "tsafe";
+import { select } from "../grammar";
+
+// Compile tests - just check SQL output without executing
+describe("compile tests", () => {
+  it("should create a basic select query", () => {
+    // Basic select all
+    const query1 = db.Users.select();
+    const compiled1 = query1.compile();
+    const result1 = compiled1.compile(dummyDb);
+
+    expect(result1.sql).toBe(
+      'SELECT "users"."active" AS "active", "users"."email" AS "email", "users"."id" AS "id", "users"."name" AS "name", "users"."role" AS "role" FROM "users" as "users"',
+    );
+    expect(result1.parameters).toEqual([]);
+
+    // Select specific columns
+    const query2 = db.Users.select((u) => ({ id: u.id, name: u.name }));
+    const compiled2 = query2.compile();
+    const result2 = compiled2.compile(dummyDb);
+
+    expect(result2.sql).toBe(
+      'SELECT "users"."id" AS "id", "users"."name" AS "name" FROM "users" as "users"',
+    );
+    expect(result2.parameters).toEqual([]);
+  });
+
+  it("should support additional options like where clause", () => {
+    const query = db.Users.select((u) => u).where((u) =>
+      u.active["="](Types.Int4.new(1)),
+    );
+    const compiled = query.compile();
+    const result = compiled.compile(dummyDb);
+
+    expect(result.sql).toBe(
+      'SELECT "users"."active" AS "active", "users"."email" AS "email", "users"."id" AS "id", "users"."name" AS "name", "users"."role" AS "role" FROM "users" as "users" WHERE ("users"."active" = cast($1 as int4))',
+    );
+    expect(result.parameters).toEqual([1]);
+  });
+
+  it("should support ORDER BY and LIMIT", () => {
+    const query = db.Person.select((p) => ({
+      id: p.id,
+      firstName: p.firstName,
+    }))
+      .orderBy([(p) => p.createdAt, { desc: true }])
+      .limit(Types.Int4.new(10));
+    const compiled = query.compile();
+    const result = compiled.compile(dummyDb);
+
+    expect(result.sql).toBe(
+      'SELECT "person"."firstName" AS "firstName", "person"."id" AS "id" FROM "person" as "person" ORDER BY "person"."createdAt" DESC LIMIT cast($1 as int4)',
+    );
+    expect(result.parameters).toEqual([10]);
+  });
+
+  it("should support soft delete pattern through override", () => {
+    // Create a class that extends the Users table with soft delete logic using the active column
+    class ActiveUsers extends db.Users.extend<ActiveUsers>() {
+      nameName() {
+        return this.name.textcat(this.name);
+      }
+
+      static select<S extends Types.RowLike>(selectCb?: (t: ActiveUsers) => S) {
+        return select(selectCb ?? ((t: ActiveUsers) => t as S), {
+          from: this,
+          where: (t) => t.active["="](1),
+        });
+      }
+    }
+
+    // Should automatically filter for active users
+    const query = ActiveUsers.select((au) => ({
+      id: au.id,
+      nameName: au.nameName(),
+    }));
+    const compiled = query.compile();
+    const result = compiled.compile(dummyDb);
+
+    expect(result.sql).toBe(
+      'SELECT "users"."id" AS "id", textcat("users"."name", "users"."name") AS "nameName" FROM "users" as "users" WHERE ("users"."active" = $1)',
+    );
+    expect(result.parameters).toEqual([1]);
+  });
+
+  it("should work with joins", () => {
+    // For joins, we need to use select directly with the joined from item
+    const joinedFrom = db.Users.asFromItem().join(
+      db.Posts,
+      "posts",
+      (u, { posts }) => u.id["="](posts.user_id),
+    );
+
+    // Use the select function directly with the joined from
+    const query = select(
+      (u, { posts }) => ({
+        name: u.name,
+        postTitle: posts.title,
+      }),
+      {
+        from: joinedFrom,
+      },
+    );
+
+    const compiled = query.compile();
+    const result = compiled.compile(dummyDb);
+
+    expect(result.sql).toContain("JOIN");
+    expect(result.sql).toContain("posts");
+    expect(result.sql).toContain("title");
+  });
+});
+
+// E2E tests - actually execute queries against a test database
+describe("e2e tests", () => {
+  it("should execute basic select from Users table", async () => {
+    await withDb(testDb, async (kdb) => {
+      // Test select all
+      const query1 = db.Users.select((p) => p);
+      const result1 = await query1.execute(kdb);
+
+      assert<
+        Equals<
+          typeof result1,
+          {
+            active: number | null;
+            email: string;
+            id: number;
+            name: string;
+            role: string | null;
+          }[]
+        >
+      >();
+
+      expect(result1).toBeDefined();
+      expect(Array.isArray(result1)).toBe(true);
+
+      // Test select specific columns
+      const query2 = db.Users.select((u) => ({
+        userId: u.id,
+        userName: u.name,
+      }));
+      const result2 = await query2.execute(kdb);
+
+      assert<
+        Equals<
+          typeof result2,
+          {
+            userId: number;
+            userName: string;
+          }[]
+        >
+      >();
+
+      expect(result2).toBeDefined();
+      expect(Array.isArray(result2)).toBe(true);
+    });
+  });
+
+  it("should execute select with WHERE clause", async () => {
+    await withDb(testDb, async (kdb) => {
+      // Test select with WHERE on Person table
+      const query = db.Person.select((p) => ({
+        id: p.id,
+        fullName: p.firstName.textcat(Types.Text.new(" ")).textcat(p.lastName),
+      })).where((p) => p.id["<="](Types.Int4.new(2)));
+      const result = await query.execute(kdb);
+
+      assert<
+        Equals<
+          typeof result,
+          {
+            id: number;
+            fullName: string | null;
+          }[]
+        >
+      >();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+      // The test might run without seed data, so we just check the types are correct
+      if (result.length > 0) {
+        result.forEach((row) => {
+          expect(row).toHaveProperty("id");
+          expect(row).toHaveProperty("fullName");
+          expect(row.id).toBeLessThanOrEqual(2);
+        });
+      }
+    });
+  });
+
+  it("should execute select with ORDER BY and LIMIT", async () => {
+    await withDb(testDb, async (kdb) => {
+      // Test select with ORDER BY and LIMIT on Pet table
+      const query = db.Pet.select((p) => ({ name: p.name, age: p.age }))
+        .orderBy([(p) => p.age, { desc: true }])
+        .limit(Types.Int4.new(2));
+
+      const result = await query.execute(kdb);
+
+      assert<
+        Equals<
+          typeof result,
+          {
+            name: string;
+            age: number;
+          }[]
+        >
+      >();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+      // Should have at most 2 results
+      expect(result.length).toBeLessThanOrEqual(2);
+
+      // Check ordering if there are results
+      if (result.length > 1) {
+        for (let i = 1; i < result.length; i++) {
+          expect(result[i - 1].age).toBeGreaterThanOrEqual(result[i].age);
+        }
+      }
+    });
+  });
+});

--- a/src/query/values.ts
+++ b/src/query/values.ts
@@ -62,6 +62,20 @@ export class TableReferenceExpression extends SelectableExpression {
   }
 }
 
+// Like `TableReferenceExpression` but referencing a table directly (not an alias)
+export class RawTableReferenceExpression extends SelectableExpression {
+  constructor(
+    public table: string,
+    schema: RowLike,
+  ) {
+    super(schema);
+  }
+
+  compile(_ctx: Context) {
+    return sql.ref(this.table);
+  }
+}
+
 export class ValuesExpression extends SelectableExpression {
   constructor(public values: [RowLike, ...RowLike[]]) {
     super(values[0]);

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -6,10 +6,10 @@ import { RawBuilder, sql } from "kysely";
 import {
   ColumnAliasExpression,
   RawColumnAliasExpression,
+  RawTableReferenceExpression,
   TableReferenceExpression,
 } from "../query/values";
 import { Context } from "../expression";
-import { RawTableReferenceExpression } from "../query/db";
 
 export class LiteralRecordExpression extends Expression {
   constructor(


### PR DESCRIPTION
This PR establishes the core pattern for querying by adding a static `.select()` method to table models.

This method serves two key purposes:
1. It provides a clean, ergonomic entry point into the query builder, directly from the model itself.
2. It creates a powerful pattern for defining default scopes. Subclasses can override this method to automatically apply filters, such as for soft deletes (`WHERE deleted_at IS NULL`), to every query.

Example from the tests:

```ts

class ActiveUsers extends db.Users.extend<ActiveUsers>() {
  static select<S extends Types.RowLike>(selectCb?: (t: ActiveUsers) => S) {
    return select(selectCb ?? ((t: ActiveUsers) => t as S), {
      from: this,
      where: (t) => t.active["="](1),
    });
  }
}

// ...

// Query:
ActiveUsers.select((au) => ({
  id: au.id,
 }))

// SQL:
// SELECT "users"."id" AS "id" FROM "users" as "users" WHERE ("users"."active" = $1)
```

This is a key difference from other ORMs: **default scopes are not a special, "bolted-on" feature**. They are the natural, emergent behavior of composing standard TypeScript classes and methods.