### PR TITLE
insert: VALUES accept typegres expressions (parity with SET)

### DIFF
--- a/src/builder/insert.test.ts
+++ b/src/builder/insert.test.ts
@@ -35,6 +35,48 @@ test("insert", async () => {
   });
 });
 
+test("VALUES accept typegres expressions, not just primitives", async () => {
+  await withinTransaction(async (tx) => {
+    await tx.execute(sql`CREATE TABLE users (
+      id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      name text NOT NULL
+    )`);
+    await tx.execute(sql`CREATE TABLE posts (
+      id int8 GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      author_id int8 NOT NULL,
+      body text NOT NULL
+    )`);
+    class Users extends db.Table("users") {
+      id = Int8.column({ nonNull: true, generated: true });
+      name = Text.column({ nonNull: true });
+    }
+    class Posts extends db.Table("posts") {
+      id = Int8.column({ nonNull: true, generated: true });
+      author_id = Int8.column({ nonNull: true });
+      body = Text.column({ nonNull: true });
+    }
+
+    // A hydrated row's columns are typegres expressions, not primitives —
+    // and they flow straight into another table's VALUES (parity with SET).
+    await tx.execute(Users.insert({ name: "alice" }));
+    const [alice] = await tx.hydrate(Users.from().where(({ users }) => users.name.eq("alice")));
+
+    const [post] = await tx.execute(
+      Posts.insert({ author_id: alice!.id, body: "hi" }).returning(({ posts }) => ({
+        author_id: posts.author_id,
+      })),
+    );
+
+    // The FK landed alice's id: joining back recovers her name.
+    const [row] = await tx.execute(
+      Users.from()
+        .where(({ users }) => users.id.eq(post!.author_id))
+        .select(({ users }) => ({ name: users.name })),
+    );
+    expect(row).toEqual({ name: "alice" });
+  });
+});
+
 test("insert returning", async () => {
   await withinTransaction(async (tx) => {
     await tx.execute(sql`CREATE TABLE items (

--- a/src/builder/insert.ts
+++ b/src/builder/insert.ts
@@ -4,7 +4,7 @@ import type { RowType, RowTypeToTsType } from "./query";
 import { compileSelectList, isRowType, mergeReturning, reAlias } from "./query";
 import type { TableBase } from "../table";
 import { Connection } from "../database";
-import { getColumn } from "../types/sql-value";
+import { getColumn, SqlValue } from "../types/sql-value";
 import { meta } from "../types/sql-value";
 import { fn, expose } from "../exoeval/tool";
 import z from "zod";
@@ -62,6 +62,11 @@ export class FinalizedInsert<Name extends string, T extends TableBase, R extends
             `The '${tableCls.database.dialect}' dialect cannot express "use the column default" per row — ` +
             `provide '${k}' in every row or in none.`,
           );
+        }
+        if (v instanceof SqlValue) {
+          // Already a typegres expression (e.g. a hydrated column from
+          // another row) — embed it directly, don't re-wrap as a param.
+          return v.toSql();
         }
         const col = getColumn(instance, k);
         return col[meta].__class.from(v).toSql();

--- a/src/types/runtime.ts
+++ b/src/types/runtime.ts
@@ -70,9 +70,12 @@ export type OptionalKeys<R> = {
   [K in ColumnKeys<R>]: IsRequired<R[K]> extends true ? never : K;
 }[ColumnKeys<R>];
 
-// Insert row: required columns + optional columns (as TsTypeOf)
-export type InsertRow<R> = { [K in RequiredKeys<R>]: TsTypeOf<R[K]> } & {
-  [K in OptionalKeys<R>]?: TsTypeOf<R[K]>;
+// Insert row: required columns + optional columns. Like SET (SetRow), each
+// value is either the JS-side primitive or a typegres expression of the
+// same class & nullability — a hydrated column from another row composes
+// straight into VALUES.
+export type InsertRow<R> = { [K in RequiredKeys<R>]: TsTypeOf<R[K]> | StripRequired<R[K]> } & {
+  [K in OptionalKeys<R>]?: TsTypeOf<R[K]> | StripRequired<R[K]>;
 };
 
 // Drop the column-only `__required` marker from a column type's meta.


### PR DESCRIPTION
InsertRow widens each column to `TsTypeOf | StripRequired` (same shape as SetRow), and the compile path embeds an incoming SqlValue via toSql() instead of re-wrapping it as a param. A hydrated column from one row now composes straight into another table's insert — no unwrap-to-primitive step. Covered in insert.test.ts.