### PR TITLE
ci: run examples/sqlite in check-examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           else
             RUN=(bash -c)
           fi
-          "${RUN[@]}" "cd '$PWD' && nix develop --command bash -c 'set -e; bin/startpg; (cd packages/capnweb && npm ci && npm run build); npm ci; (cd examples/basic && npm ci); (cd examples/chat && npm ci); (cd site && npm ci); npm run codegen:check; npm run build; npm run check; (cd site && npm run typecheck && npm run test)'"
+          "${RUN[@]}" "cd '$PWD' && nix develop --command bash -c 'set -e; bin/startpg; (cd packages/capnweb && npm ci && npm run build); npm ci; (cd examples/basic && npm ci); (cd examples/sqlite && npm ci); (cd examples/chat && npm ci); (cd site && npm ci); npm run codegen:check; npm run build; npm run check; (cd site && npm run typecheck && npm run test)'"
 
   site:
     needs: check

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "format": "prettier --write src",
     "test": "vitest run",
     "check": "npm run lint && npm run typecheck && npm run test && npm run check-examples",
-    "check-examples": "npm --prefix examples/basic run check && npm --prefix examples/chat run check",
+    "check-examples": "npm --prefix examples/basic run check && npm --prefix examples/sqlite run check && npm --prefix examples/chat run check",
     "test:do": "vitest run --project workerd"
   },
   "devDependencies": {


### PR DESCRIPTION
check-examples covered examples/basic and examples/chat but not examples/sqlite, so `npm run check` never compiled or ran it — even though the previous commit edited its db.ts. Add it, plus the matching `npm ci` in the workflow so the install is there when it runs.

Verified locally: tsgo --noEmit clean, vitest 6/6.