### PR TITLE
fix: add repository field for provenance validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "typegres",
   "version": "0.3.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ryanrasti/typegres.git"
+  },
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",


### PR DESCRIPTION
npm's sigstore provenance check requires package.json repository.url to match the GitHub repo the build ran from; without it the publish fails with E422 after signing.