### PR TITLE
fix: don't drop the live schema while the poller is still running

### DIFF
--- a/src/live/bus.ts
+++ b/src/live/bus.ts
@@ -312,7 +312,13 @@ export class Bus {
   #startLoop(): void {
     this.#loopPromise = (async () => {
       while (this.#running) {
-        await this.#poll();
+        try {
+          await this.#poll();
+        } catch (e) {
+          // stop() flipped #running while a poll was in flight (or the
+          // schema vanished under us). Shutdown is not a poll failure.
+          if (this.#running) { throw e; }
+        }
         const waiters = this.#oncePolled.splice(0);
         for (const w of waiters) {
           w();

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -66,7 +66,9 @@ export const setupDb = (): void => {
   });
 
   afterAll(async () => {
-    await conn.execute(sql`DROP SCHEMA IF EXISTS ${db.scopedIdent(schema)} CASCADE`);
+    // Stop the poller first. Don't DROP SCHEMA here — a concurrent poll
+    // can race the drop (max: 1 pool, two-query poll). Next beforeAll
+    // already drops leftover schema.
     await conn.close();
   });
 };


### PR DESCRIPTION
afterAll DROP SCHEMA raced Bus.#poll: the poll is two queries with a release between them, and they share a pool of max: 1. DROP in that gap made the events SELECT fail; close() → stop() then surfaced it as a suite failure.

Stop the poller first and leave leftover schema for the next setupDb beforeAll. Swallow in-flight poll errors once stop() has already flipped #running.